### PR TITLE
Update knockouch.js

### DIFF
--- a/knockouch/src/knockouch.js
+++ b/knockouch/src/knockouch.js
@@ -117,8 +117,8 @@
             return window.jQuery.mobile ? true : false;
         },
         eventSubstitutes: {
-            'swipeleft': 'swipeLeft',
-            'swiperight': 'swipeRight',
+            'swipeleft': 'swipeleft',
+            'swiperight': 'swiperight',
             'hold': 'taphold',
             'tap': 'tap',
             'swipe': 'swipe'


### PR DESCRIPTION
Fixed jquery mobile swipeleft and swiperight bindings. These were not working as event is case sensitive.